### PR TITLE
Fixed elro home easy protocol

### DIFF
--- a/lib/protocols/switch2.js
+++ b/lib/protocols/switch2.js
@@ -32,7 +32,7 @@ module.exports = function(helper) {
       return result = {
         houseCode: helper.binaryToNumber(binary, 0, 4),
         unitCode: helper.binaryToNumber(binary, 5, 9),
-        state: helper.binaryToBoolean(binary, 10)
+        state: (helper.binaryToBoolean(binary, 11) ? false : true)
       };
     },
     encodeMessage: function(message) {


### PR DESCRIPTION
It is better to use the second state and invert it, because I think it's more compatible.
Pilight does it the same way.
With this change I can use my wallswitches with this protocol.